### PR TITLE
fix: support without site title

### DIFF
--- a/src/layouts/DocLayout/DocumentLayout.tsx
+++ b/src/layouts/DocLayout/DocumentLayout.tsx
@@ -59,7 +59,7 @@ const DocumentLayout = memo(() => {
           <title>{siteTitle}</title>
         ) : (
           <title>
-            {fm.title} - {siteTitle}
+            {siteTitle ? `${fm.title}-${siteTitle}` : fm.title}
           </title>
         )}
       </Helmet>


### PR DESCRIPTION
close #47

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
Sometimes the site title may not be configured, which results in white screens on all pages except for the homepage.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
![image](https://github.com/user-attachments/assets/5e04b496-47f4-4788-9022-ab40f05ba869)
