### PR TITLE
🐛 fix: unable to override `footer` and `metadata` configuration

### DIFF
--- a/src/store/selectors/site.ts
+++ b/src/store/selectors/site.ts
@@ -6,7 +6,7 @@ import { AnchorItem } from '@/types';
 
 import { SiteStore } from '../useSiteStore';
 
-const themeConfig = (s: SiteStore) => merge(s.siteData.themeConfig, initialThemeConfig);
+const themeConfig = (s: SiteStore) => merge(initialThemeConfig, s.siteData.themeConfig);
 const siteTitle = (s: SiteStore) => themeConfig(s).title;
 const siteDesc = (s: SiteStore) => themeConfig(s).description;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Because `initialThemeConfig` is the second parameter in the `merge` method, it prevents `footer` and `metadata` from being modified externally.

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
