### PR TITLE
🐛 fix: Sync Table of Contents (TOC) with scroll position

### DIFF
--- a/src/slots/Toc/index.tsx
+++ b/src/slots/Toc/index.tsx
@@ -25,7 +25,7 @@ const Toc = memo(() => {
     <>
       {!mobile && <div style={{ height: spacing }} />}
       <T
-        getContainer={() => document?.body}
+        getContainer={() => window}
         headerHeight={theme.headerHeight}
         isMobile={mobile}
         items={items}

--- a/src/slots/Toc/index.tsx
+++ b/src/slots/Toc/index.tsx
@@ -25,7 +25,7 @@ const Toc = memo(() => {
     <>
       {!mobile && <div style={{ height: spacing }} />}
       <T
-        getContainer={() => window}
+        getContainer={typeof window !== 'undefined' ? () => window : undefined}
         headerHeight={theme.headerHeight}
         isMobile={mobile}
         items={items}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Fix Table of Contents scroll syncing by targeting the window as the container instead of the document body.